### PR TITLE
API Formfield validation for nested groups and pages

### DIFF
--- a/code/extensions/UserFormFieldEditorExtension.php
+++ b/code/extensions/UserFormFieldEditorExtension.php
@@ -115,7 +115,7 @@ class UserFormFieldEditorExtension extends DataExtension {
 
 		// Add step
 		$step = EditableFormStep::create();
-		$step->Title = _t('EditableFormStep.TITLE_FIRST', 'First Step');
+		$step->Title = _t('EditableFormStep.TITLE_FIRST', 'First Page');
 		$step->Sort = 1;
 		$step->write();
 		$fields->add($step);

--- a/code/extensions/UserFormValidator.php
+++ b/code/extensions/UserFormValidator.php
@@ -1,0 +1,108 @@
+<?php
+
+
+class UserFormValidator extends RequiredFields {
+	public function php($data) {
+		if(!parent::php($data)) {
+			return false;
+		}
+
+		// Skip unsaved records
+		if(empty($data['ID']) || !is_numeric($data['ID'])) {
+			return true;
+		}
+
+		$fields = EditableFormField::get()->filter('ParentID', $data['ID'])->sort('"Sort" ASC');
+
+		// Current nesting
+		$stack = array();
+		foreach($fields as $field) {
+			if($field instanceof EditableFormStep) {
+				// Page at top level, or after another page is ok
+				if(empty($stack) || (count($stack) === 1 && $stack[0] instanceof EditableFormStep)) {
+					$stack = array($field);
+					continue;
+				}
+
+				$this->validationError(
+					'FormFields',
+					_t(
+						"UserFormValidator.UNEXPECTED_BREAK",
+						"Unexpected page break '{name}' inside nested field '{group}'",
+						array(
+							'name' => $field->CMSTitle,
+							'group' => end($stack)->CMSTitle
+						)
+					),
+					'error'
+				);
+				return false;
+			}
+
+			// Validate no pages
+			if(empty($stack)) {
+				$this->validationError(
+					'FormFields',
+					_t(
+						"UserFormValidator.NO_PAGE",
+						"Field '{name}' found before any pages",
+						array(
+							'name' => $field->CMSTitle
+						)
+					),
+					'error'
+				);
+				return false;
+			}
+
+			// Nest field group
+			if($field instanceof EditableFieldGroup) {
+				$stack[] = $field;
+				continue;
+			}
+
+			// Unnest field group
+			if($field instanceof EditableFieldGroupEnd) {
+				$top = end($stack);
+
+				// Check that the top is a group at all
+				if(!$top instanceof EditableFieldGroup) {
+					$this->validationError(
+						'FormFields',
+						_t(
+							"UserFormValidator.UNEXPECTED_GROUP_END",
+							"'{name}' found without a matching group",
+							array(
+								'name' => $field->CMSTitle
+							)
+						),
+						'error'
+					);
+					return false;
+				}
+
+				// Check that the top is the right group
+				if($top->EndID != $field->ID) {
+					$this->validationError(
+						'FormFields',
+						_t(
+							"UserFormValidator.WRONG_GROUP_END",
+							"'{name}' found closes the wrong group '{group}'",
+							array(
+								'name' => $field->CMSTitle,
+								'group' => $top->CMSTitle
+							)
+						),
+						'error'
+					);
+					return false;
+				}
+
+				// Unnest group
+				array_pop($stack);
+			}
+		}
+		
+		return true;
+	}
+}

--- a/code/model/UserDefinedForm.php
+++ b/code/model/UserDefinedForm.php
@@ -286,6 +286,14 @@ SQL;
 		
 		DB::alteration_message('Migrated userforms', 'changed');
 	}
+
+
+	/**
+	 * Validate formfields
+	 */
+	public function getCMSValidator() {
+		return new UserFormValidator();
+	}
 }
 
 /**

--- a/code/model/editableformfields/EditableFieldGroup.php
+++ b/code/model/editableformfields/EditableFieldGroup.php
@@ -5,6 +5,10 @@
  */
 class EditableFieldGroup extends EditableFormField {
 
+	private static $has_one = array(
+		'End' => 'EditableFieldGroupEnd'
+	);
+
 	/**
 	 * Disable selection of group class
 	 *
@@ -19,11 +23,18 @@ class EditableFieldGroup extends EditableFormField {
 		return $fields;
 	}
 
-	public function getInlineClassnameField($column, $fieldClasses) {
-		return new LabelField(
-			$column,
-			_t('EditableFieldGroup.FIELD_GROUP_START', 'Field Group (start)')
+	public function getCMSTitle() {
+		return _t(
+			'EditableFieldGroupEnd.FIELD_GROUP_START',
+			'Start of {group}',
+			array(
+				'group' => $this->Title ?: 'group'
+			)
 		);
+	}
+
+	public function getInlineClassnameField($column, $fieldClasses) {
+		return new LabelField($column, $this->CMSTitle);
 	}
 
 	public function showInReports() {
@@ -47,6 +58,22 @@ class EditableFieldGroup extends EditableFormField {
 		// if this field has an extra class
 		if($field->ExtraClass) {
 			$field->addExtraClass($field->ExtraClass);
+		}
+	}
+
+	protected function onBeforeDelete() {
+		parent::onBeforeDelete();
+
+		// Ensures EndID is lazy-loaded for onAfterDelete
+		$this->EndID;
+	}
+
+	protected function onAfterDelete() {
+		parent::onAfterDelete();
+
+		// Delete end
+		if(($end = $this->End()) && $end->exists()) {
+			$end->delete();
 		}
 	}
 	

--- a/code/model/editableformfields/EditableFormField.php
+++ b/code/model/editableformfields/EditableFormField.php
@@ -450,6 +450,10 @@ class EditableFormField extends DataObject {
 		return Convert::raw2xml($this->Title);
 	}
 
+	public function getCMSTitle() {
+		return $this->i18n_singular_name() . ' (' . $this->Title . ')';
+	}
+
 	/**
 	 * @deprecated since version 4.0
 	 */

--- a/code/model/editableformfields/EditableFormStep.php
+++ b/code/model/editableformfields/EditableFormStep.php
@@ -6,6 +6,10 @@
  */
 class EditableFormStep extends EditableFormField {
 
+	private static $singular_name = 'Page Break';
+
+	private static $plural_name = 'Page Breaks';
+
 	/**
 	 * Disable selection of step class
 	 *
@@ -13,18 +17,6 @@ class EditableFormStep extends EditableFormField {
 	 * @var bool
 	 */
 	private static $hidden = true;
-
-	/**
-	 * @config
-	 * @var string
-	 */
-	private static $singular_name = 'Step';
-
-	/**
-	 * @config
-	 * @var string
-	 */
-	private static $plural_name = 'Steps';
 
 	/**
 	 * @return FieldList
@@ -64,7 +56,15 @@ class EditableFormStep extends EditableFormField {
 	public function getInlineClassnameField($column, $fieldClasses) {
 		return new LabelField(
 			$column,
-			_t('EditableFieldGroupEnd.PAGE_BREAK', 'Page Break')
+			$this->CMSTitle
 		);
+	}
+
+	public function getCMSTitle() {
+		$title = $this->i18n_singular_name();
+		if($this->Title) {
+			$title .= ' (' . $this->Title . ')';
+		}
+		return $title;
 	}
 }


### PR DESCRIPTION
This doesn't block "fixing" actions such as sorting or deleting fields, but it does block saving changes to fields (such as renaming) until these issues are resolved.

This validates things such as pages inside nested groups, end of groups closing the wrong start of groups, and hanging end of groups.