### PR TITLE
Fix live validation

### DIFF
--- a/javascript/UserForm.js
+++ b/javascript/UserForm.js
@@ -71,7 +71,7 @@ jQuery(function ($) {
 	 */
 	UserForm.prototype.validationOptions = {
 		ignore: ':hidden',
-		errorClass: 'required',
+		errorClass: 'error',
 		errorElement: 'span',
 		errorPlacement: function (error, element) {
 			error.addClass('message');
@@ -500,11 +500,9 @@ jQuery(function ($) {
 
 		// Extend the default validation options with conditional options
 		// that are set by the user in the CMS.
-		if (CONSTANTS.ENABLE_LIVE_VALIDATION) {
+		if (CONSTANTS.ENABLE_LIVE_VALIDATION === false) {
 			$.extend(UserForm.prototype.validationOptions, {
-				onfocusout: function (element) {
-					this.element(element);
-				}
+				onfocusout: false
 			});
 		}
 


### PR DESCRIPTION
To test this:

- Create a Text field
- In the field's "validation" tab set the min text length to "2"

By default live validation is disabled, so entering one character into the field on the front-end and tabbing away doesn't display an error.

Enable live validation on the userform in the CMS.

Go back to the form on the front-end, enter one character and tab away, an error is displayed.